### PR TITLE
ci: run Playwright e2e suite on every PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,26 @@ jobs:
           paths: "/index.html"
           distribution_id: $SANDBOX_DISTRIBUTION_ID
 
+  e2e:
+    # Playwright regression net (PR 1.1). Runs the suite against the real app on
+    # every branch / PR so breakage surfaces automatically instead of relying on
+    # someone remembering to run `yarn test:e2e` locally.
+    docker:
+      # Node 20 + the system libs a browser needs, preinstalled. (The deploy job
+      # above stays on Node 14 — Playwright needs >=18, so this job rents a newer
+      # image; the two jobs never share a machine.)
+      - image: cimg/node:20-browsers
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: cd er && yarn install --frozen-lockfile
+      - run:
+          name: Run Playwright e2e suite
+          # `pretest:e2e` installs the Chromium binary; the dev server is booted
+          # by playwright.config.ts (webServer), so no separate `yarn start`.
+          command: cd er && yarn test:e2e
+
 workflows:
   build_deploy:
     jobs:
@@ -34,3 +54,5 @@ workflows:
               branches:
                 only:
                   - develop
+      # No branch filter: the regression net should run on every PR / branch.
+      - e2e


### PR DESCRIPTION
| Field | Value |
| --- | --- |
| **Change type** | ♻️ same behavior (chore / ci) |
| **Risk severity** | S4 low |

## Summary
Add a CircleCI `e2e` job that runs the Playwright regression suite on every branch / PR, so breakage surfaces automatically instead of relying on someone remembering to run `yarn test:e2e` locally. Follow-up to #34.

## Decisions & alternatives
- **Approach & why:** new `e2e` job on `cimg/node:20-browsers`, no branch filter so it runs on all PRs. Kept separate from the existing `deploy_testER` job, which stays on Node 14 — Playwright needs Node ≥18, so this job rents its own newer image; the two never share a machine.
- **Alternatives considered & why rejected:**
  - *Reuse the deploy job's Node 14 image* — rejected, Playwright requires Node ≥18.
  - *GitHub Actions instead of CircleCI* — open question (see note below). Kept this on CircleCI to match the existing pipeline, but happy to switch if the team prefers?
- **Trade-offs / what could go wrong:** the webpack-4 + `--openssl-legacy-provider` dev server booting under Node 20 in CI is the main unknown; may need a small tweak once it runs live.

## Links
- Design doc / two-pager: N/A
- Issues / related PRs: **Depends on #34** (the e2e suite + `test:e2e` script). Merge #34 first — this job has nothing to run until those files are on `develop`.

## Tests — how do we know it's safe? *(check all used)*
- [ ] Unit
- [ ] Integration
- [ ] Contract
- [x] Synthetic / e2e — the suite this job runs passes locally (7/7 green on Node 20)
- [x] Manual — `config.yml` YAML structure validated locally
- [ ] None

> ⚠️ CI-side verification is still pending: CircleCI won't run on PRs from a fork until **"Build forked pull requests"** is enabled (admin setting), so this job's first real run happens after that toggle.

## Incident detection — if this breaks in prod, how will we know?
CI-only change, no runtime / prod impact. A misconfigured job shows red on the PR in CircleCI — that's the signal.

## Incident impact analysis — can we measure the blast radius?
Blast radius is limited to CI. Until this check is marked **required** in branch protection, a failing or broken job blocks nothing and has zero user impact.

## Rollback & mitigation — if it goes wrong, how do we fix it fast?
- Safe to plain-revert? **Yes** — single-file change to `.circleci/config.yml`; reverting removes the job cleanly.
- Rollout: direct.
- If revert isn't enough: N/A.

---

### To make this an actual merge gate (admin only)
Two settings I can't reach as an outside contributor:
1. **CircleCI → Project Settings → Advanced → enable "Build forked pull requests"** (so it runs on fork PRs at all).
2. **GitHub → Settings → Branches → branch protection for `develop` → "Require status checks to pass before merging" → select the `e2e` check.** The check only appears in that list *after* it has run once, so do #1 first.
